### PR TITLE
Clarify Hammer Gate authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Every phase transition passes through a **Ratify** gate — a forced cognitive m
 
 **"Drop the Hammer"** = the decision between PLAN and HAMMER. After this, you commit to building. Before it, everything is reversible.
 
+The decision must be recorded in GitHub before HAMMER starts. See [Hammer Gate and Execution Authorization Contract](knowledge/hammer-gate.md). Vague phrases such as `go`, `continue`, `execute`, `I trust you`, or `do your best` may continue planning, but they do not authorize HAMMER.
+
 ## Phase Classification
 
 | Phases | Domain | What's Happening |
@@ -73,7 +75,7 @@ Each gate has a **phase-specific protocol** — different prompts, different che
 | R3 Spec | ASSAY | **Hard** | ≥ 8/10 + Independent Observer |
 | R4 Adversarial | CRUCIBLE | **Hard** | ≥ 8/10 + all domains scored |
 | **R4b Auditor** | **Ext. Auditor** | **Hard** | Different model, verdict YES/CONDITIONAL |
-| R5 Ready | PLAN | **Hard** | ≥ 8/10 + "Drop the Hammer" |
+| R5 Ready | PLAN | **Hard** | ≥ 8/10 + GitHub Hammer Authorization Record |
 | R6 Build | HAMMER | **Hard** | ≥ 8/10 + tests pass |
 | R7 Ship | TEMPER | **Hard** | ≥ 9/10 + evidence for every claim |
 | **R-AR AutoResearch** | **AUTORESEARCH** | **Hard** | program.md written, experiments run, findings ratcheted |

--- a/knowledge/hammer-gate.md
+++ b/knowledge/hammer-gate.md
@@ -1,0 +1,85 @@
+# Hammer Gate and Execution Authorization Contract
+
+Canonical issue: [growthpigs/the-foundry#67](https://github.com/growthpigs/the-foundry/issues/67)
+
+The Hammer Gate is the boundary between reversible planning and execution. It exists to keep the Foundry autonomous without becoming aggressive.
+
+## Rule
+
+HAMMER does not begin until the project has a GitHub-recorded Hammer Authorization Record.
+
+Local markdown files may mirror the record, but GitHub is the source of truth. If a local note and the GitHub record disagree, GitHub wins.
+
+## Authorizing Language
+
+These phrases authorize HAMMER when scoped to a specific issue, epic, or milestone:
+
+- `Drop the Hammer`
+- `HAMMER_AUTHORIZED`
+- `Start HAMMER for <specific issue/epic>`
+
+These phrases do not authorize HAMMER:
+
+- `go`
+- `continue`
+- `execute`
+- `I trust you`
+- `do your best`
+- `act as CTO/PM`
+- `keep going`
+
+Non-authorizing phrases may continue planning, GitHub cleanup, backlog preparation, docs, reversible local analysis, or dry-run verification. They do not authorize code changes, live infrastructure changes, production-bound migrations, paid resource upgrades, deploys, merges, or destructive operations.
+
+## Hammer Authorization Record
+
+Before HAMMER begins, post this as a GitHub issue comment on the parent issue, PRD issue, or epic issue:
+
+```md
+## Hammer Authorization Record
+
+Scope: <issue/epic/milestone URL>
+Authorized by: Roderic
+Authorization phrase: "Drop the Hammer"
+Allowed operations:
+- Branches, commits, tests, docs, issue comments, draft PRs
+- <any extra explicitly approved operations>
+
+Explicitly not authorized unless separately approved:
+- Merges to main or production branches
+- Production deploys
+- Live database migrations or destructive SQL
+- Paid infrastructure creation or upgrades
+- Secrets rotation or credential changes
+- External client/user communications
+- Any operation outside the scoped issue/epic/milestone
+```
+
+HAMMER agents must read this record from GitHub before implementation. A local copy is not enough.
+
+## Production-Bound Line Items
+
+Even after HAMMER is authorized, these operations require their own explicit approval line in GitHub:
+
+- Applying migrations to a live or production-bound database
+- Creating, upgrading, or deleting paid infrastructure
+- Changing secrets, auth providers, RLS policies, or credential paths
+- Deploying to production or promoting staging to production
+- Merging to `main`, `production`, or any release branch
+- Destructive git operations such as force-push, branch deletion, or reset
+- Partner-visible decisions, HR/accounting judgments, or binding arbitration outputs
+
+If the authorization record does not mention the operation, stop and ask for that specific approval.
+
+## Runtime Behavior
+
+PLAN may create specs, issues, milestones, checklists, and dry-run validation. PLAN stops at backlog readiness unless the Hammer Authorization Record exists.
+
+HAMMER starts with a preflight:
+
+1. Find the canonical GitHub issue, PRD issue, or epic issue.
+2. Read the issue body and latest comments.
+3. Confirm a Hammer Authorization Record exists.
+4. Confirm the requested work is inside the recorded scope.
+5. Confirm any production-bound line item is explicitly approved.
+
+If any check fails, do not implement. Post the missing authorization need to GitHub and report it to Roderic.

--- a/modes/STAGE-MAP.md
+++ b/modes/STAGE-MAP.md
@@ -75,8 +75,8 @@ FOUNDRY PHASE          PIPELINE STAGES (foundry.sh)
 | SCOUT | Partially | `explore` stage runs, but IDEO sprint / art direction are manual skills |
 | ASSAY | Yes | `issue` → `user-stories` → `fsd` stages |
 | CRUCIBLE | Yes | `issue-review` → `red-team` stages. NotebookLM artifact verification is enforced when `--require-notebook-crucible` is set. |
-| PLAN | No | GitHub issue creation via `foundry-pipe-02-scrum-master` skill |
-| HAMMER | Yes | `anti-regression` → `code` → `validate` stages |
+| PLAN | No | GitHub issue creation via `foundry-pipe-02-scrum-master` skill. Stops at backlog readiness unless the GitHub Hammer Authorization Record exists. |
+| HAMMER | Yes | Starts only after Hammer Gate preflight, then `anti-regression` → `code` → `validate` stages. |
 | TEMPER | Yes | `e2e` → `pr` → `pr-review` → `compliance` → `follow-up` stages |
 | AUTORESEARCH | Partially | `autoresearch` stage runs agent loop; `program.md` is human-authored |
 

--- a/phases/05-plan.md
+++ b/phases/05-plan.md
@@ -87,7 +87,17 @@ Create `.foundry/tool-registry.json`:
 
 This is the explicit moment where you say: "The specs are done. The Crucible found nothing blocking. The issues are created. We are ready to code."
 
-**This is NOT automatic.** It's a conscious decision. The Candid Self-Assessment (Article 24) runs here:
+**This is NOT automatic.** It's a conscious decision, and it must be recorded in GitHub before HAMMER starts. See [Hammer Gate and Execution Authorization Contract](../knowledge/hammer-gate.md).
+
+Only explicit scoped authorization starts HAMMER:
+
+- `Drop the Hammer`
+- `HAMMER_AUTHORIZED`
+- `Start HAMMER for <specific issue/epic>`
+
+Phrases such as `go`, `continue`, `execute`, `I trust you`, `do your best`, or `keep going` are not enough. They may authorize continued planning or cleanup, but they do not authorize implementation.
+
+The Candid Self-Assessment (Article 24) runs here:
 
 ```
 1. WHERE ARE WE NOW? Status, what changed, what's unchanged.
@@ -101,12 +111,37 @@ This is the explicit moment where you say: "The specs are done. The Crucible fou
 
 Any score below 7 → BLOCKED. Go back to ASSAY.
 
+#### Hammer Authorization Record
+
+Post the authorization as a GitHub issue comment on the parent issue, PRD issue, or epic issue:
+
+```md
+## Hammer Authorization Record
+
+Scope: <issue/epic/milestone URL>
+Authorized by: Roderic
+Authorization phrase: "Drop the Hammer"
+Allowed operations:
+- Branches, commits, tests, docs, issue comments, draft PRs
+
+Explicitly not authorized unless separately approved:
+- Merges to main or production branches
+- Production deploys
+- Live database migrations or destructive SQL
+- Paid infrastructure creation or upgrades
+- Secrets rotation or credential changes
+- External client/user communications
+```
+
+Production-bound infrastructure, live database migrations, secrets, paid resources, deploys, merges, destructive operations, and partner-visible binding decisions require explicit line-item authorization in GitHub even after HAMMER starts.
+
 ### Outputs
 - GitHub Issues (all stories with acceptance criteria)
 - Sprint plan (stories assigned to sprints)
 - Epic dependency graph
 - Work Ledger updated with planning DUs
-- "Hammer Decision" documented in Activity Log
+- Hammer Authorization Record posted to GitHub
+- Optional local mirrors updated from the GitHub record
 
 ---
 

--- a/phases/06-hammer.md
+++ b/phases/06-hammer.md
@@ -17,10 +17,25 @@ Code drops. The specs from ASSAY, validated by CRUCIBLE, planned in PLAN, are no
 - [ ] Anti-regression baseline (captured before first code change)
 - [ ] Deployment pipeline (verified in PLAN)
 - [ ] **Carry-forward from PLAN** in progress.txt (architectural decisions, dependency order, risks flagged)
+- [ ] **Hammer Authorization Record** in GitHub, scoped to this issue/epic/milestone
 
 **If any input is missing → HAMMER cannot start. Go back to the phase that should have produced it.**
 
 ### Process
+
+#### Step -1: Hammer Gate Preflight
+
+Before any code, worktree, migration, or infrastructure change:
+
+1. Read the canonical GitHub parent issue, PRD issue, or epic issue.
+2. Confirm it contains a `Hammer Authorization Record`.
+3. Confirm the authorization phrase is one of: `Drop the Hammer`, `HAMMER_AUTHORIZED`, or `Start HAMMER for <specific issue/epic>`.
+4. Confirm the requested work is inside the authorized scope.
+5. Confirm production-bound line items are explicitly approved when relevant.
+
+Vague phrases such as `go`, `continue`, `execute`, `I trust you`, `do your best`, or `keep going` do not pass this gate.
+
+If the record is missing or incomplete, stop. Post the missing authorization need to GitHub and return to PLAN.
 
 #### Execution Modes
 
@@ -68,8 +83,8 @@ For larger features, HAMMER uses the Ralph pattern:
 #### Dark Factory Mode (Level 5)
 
 When running fully autonomous (Long Run Mode, Article 30):
-- No approval needed for: branches, commits, issue updates, doc changes, test runs, draft PRs
-- Still needs approval for: merging to main, production deploys, destructive git operations
+- No additional approval needed for authorized reversible work: branches, commits, issue updates, doc changes, test runs, draft PRs
+- Still needs explicit line-item approval for: merging to main, production deploys, live database migrations, destructive SQL, paid infrastructure changes, secrets changes, destructive git operations, and external communications
 - Activity Log updated every turn (not just at end)
 - Work Ledger updated at session wrap
 


### PR DESCRIPTION
## Summary

Fixes #67.

This hardens the Foundry boundary between PLAN and HAMMER so agents cannot drift from planning into implementation or production-bound infrastructure work on vague approval language.

## Changes

- Adds `knowledge/hammer-gate.md` as the operational contract for execution authorization.
- Updates PLAN so the Hammer Decision must be recorded in GitHub as a Hammer Authorization Record.
- Updates HAMMER so implementation starts with a GitHub Hammer Gate preflight.
- Updates the stage map so PLAN stops at backlog readiness unless the gate is passed.
- Clarifies that production-bound actions require explicit line-item approval even after HAMMER starts.

## Verification

- `git diff --check`
- `bash -n bin/foundry.sh bin/launch.sh bin/create-foundation.sh`
- `rg "Hammer Authorization Record|Hammer Gate|Drop the Hammer|I trust you|production-bound|line-item" ...`

## Runtime note

Installed local runtime skills were updated to mirror this behavior immediately. The canonical methodology change is this PR and issue #67.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established formal "Hammer Gate" authorization process requiring explicit, scoped GitHub approval records
  * Vague language no longer permits execution; specific authorization phrases required
  * Defined production-bound operations requiring separate approval (deploys, migrations, secrets management, external communications)
  * Updated phase documentation with new authorization framework and preflight validation steps

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/growthpigs/the-foundry/pull/68)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->