### PR TITLE
Loader enforcement of CLIENT tier + borderline rulings + first repo CI (#73)

### DIFF
--- a/.github/workflows/foundry-ci.yml
+++ b/.github/workflows/foundry-ci.yml
@@ -1,0 +1,20 @@
+name: Foundry CI
+
+# First CI for this repo (#73). GitHub-hosted ubuntu-latest on purpose — must not
+# depend on the self-hosted Mac fleet being awake.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  constitution-tiering:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Syntax-check orchestrator + loader lib
+        run: bash -n bin/foundry.sh && bash -n bin/lib/constitution-loader.sh
+      - name: Constitution tiering unit tests
+        run: bash bin/__tests__/constitution-tiering.test.sh

--- a/.github/workflows/foundry-ci.yml
+++ b/.github/workflows/foundry-ci.yml
@@ -14,6 +14,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Syntax-check orchestrator + loader lib
         run: bash -n bin/foundry.sh && bash -n bin/lib/constitution-loader.sh
       - name: Constitution tiering unit tests

--- a/CONSTITUTION-CORE.md
+++ b/CONSTITUTION-CORE.md
@@ -1,7 +1,7 @@
 # The Foundry — Constitution (Core Principles)
 
-**Version:** 3.0
-**Status:** RATIFIED (2026-03-13) · v3 amendments ratified 2026-07-17 (issue #69)
+**Version:** 3.2
+**Status:** RATIFIED (2026-03-13) · v3 amendments ratified 2026-07-17 (issues #69, #71, #73) — no CORE-tier article text changed after v3.0; version tracks `CONSTITUTION.md`
 **Scope:** Loaded for EVERY pipeline stage. Amendable ONLY via the Amendments process in `CONSTITUTION.md` — never edited autonomously by an AI agent. Mirrored articles must stay in sync with `CONSTITUTION.md` (the authoritative text).
 
 These are the non-negotiable principles. For detailed reference articles (18 Documents, Activity Log, Crucible, CI Pipeline, etc.), see `CONSTITUTION.md` (full version — loaded for ASSAY/CRUCIBLE/red-team stages only).

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -1,10 +1,11 @@
 # The Foundry — Constitution
 
-**Version:** 3.0
-**Status:** RATIFIED (2026-03-13) · v3 amendments ratified 2026-07-17 (issue #69)
+**Version:** 3.2
+**Status:** RATIFIED (2026-03-13) · v3 amendments ratified 2026-07-17 (issues #69, #71, #73)
 **Scope:** Applies to ALL pipeline runs, ALL projects, ALL modes. Amendable ONLY via the process in the Amendments section — never edited autonomously by an AI agent.
 
 **Changelog:**
+- v3.2 (2026-07-17, #71/#73): Borderline articles resolved — 16 (Slack Console) moved to CLIENT tier (its own text is engagement-shaped: "For EVERY LifeModo (and similar) project… invisible to the client"); 22 and 31 stay CORE (each carries its own product-shape applicability gate — 31 explicitly covers "Internal tools"). Loader enforcement landed: `bin/lib/constitution-loader.sh` strips CLIENT-tier articles for internal projects; tags are no longer advisory.
 - v3.1 (2026-07-17, #71): Progressive-disclosure tiering (A6, ratified "conditional"). Added the Loading Map below; tagged the client-engagement articles (14, 19, 23, 33, 34) as **CLIENT tier** — binding only for client-delivery projects, skippable for internal/methodology runs. One canonical Constitution that indexes its own tiers; no split.
 - v3.0 (2026-07-17, #69): Article 13 rewritten for the 7-phase pipeline (Dark Foundry router description was a dead-system fossil); Article 15 model list replaced with a pointer to global CLAUDE.md model policy; Article 20 vestigial "(#16)/Document #15/count at 16" corrected to Document #16 (Test Strategy) of 18; header "Immutable" replaced with amendable-by-process; Amendments section gained the close-on-diff rule.
 - v1.0 (2026-03-13): Initial ratification, 37 articles.
@@ -17,12 +18,14 @@ This document is prepended to every `claude -p` invocation in the pipeline. Thes
 
 The Constitution loads in tiers so a run only carries the rules it needs (the #14 context-budget principle). This map IS the index: every article names its tier and links to its own detail.
 
-- **CORE tier** — the methodology engine. How the pipeline itself works. Loaded on **every** stage (mirrored in `CONSTITUTION-CORE.md`). Articles 1–13, 15, 17, 18, 20, 21, 24–32, 35, 36.
-- **CLIENT tier** — client-delivery doctrine. The paperwork and billing of running a paid engagement. Loaded **only for client-delivery projects**; internal / tooling / methodology runs skip it. Articles 14 (the 18 Documents), 19 (Admin Doc Quality Gate), 23 (Service Billing Pre-Flight), 33 (Agreement), 34 (Work Ledger / DU billing).
+- **CORE tier** — the methodology engine. How the pipeline itself works. Loaded on **every** stage (mirrored in `CONSTITUTION-CORE.md`). Articles 1–13 (incl. 8b), 15, 17, 18, 20–22, 24–32, 35, 36.
+- **CLIENT tier** — client-delivery doctrine. The paperwork, interface conventions, and billing of running a paid engagement. Loaded **only for client-delivery projects**; internal / tooling / methodology runs skip it. Articles 14 (the 18 Documents), 16 (Slack Is The Console), 19 (Admin Doc Quality Gate), 23 (Service Billing Pre-Flight), 33 (Agreement), 34 (Work Ledger / DU billing).
 
-> **How the tier is decided:** an article tagged `📎 CLIENT tier` is binding only when the project is a client engagement. The pipeline loader (`bin/foundry.sh`) gates inclusion on project type — see #73 for the loader wiring that enforces this map. Until that lands, the tags are advisory: a session may skip CLIENT-tier articles when the work is plainly internal.
+> **How the tier is decided:** the tier axis is **engagement type**. Engagement-shaped doctrine (client paperwork, client-facing interface conventions) is CLIENT; articles that carry their own product-shape applicability gates (22's "When This Applies" table, 31's explicit "Internal tools" coverage) stay CORE. An article tagged `📎 CLIENT tier` is binding only when the project is a client engagement.
 
-> **Amending the map:** moving an article between tiers is a `constitution`-labeled amendment (close-on-diff rule applies). Borderline articles under review for CLIENT tier: 16 (Slack Console), 22 (Platform Self-Awareness), 31 (Linear UI) — left in CORE pending #71 thrash.
+> **Enforcement (#73):** `bin/lib/constitution-loader.sh` strips CLIENT-tier articles from the prompt for internal projects. Project type resolves from `FOUNDRY_PROJECT_TYPE` env, then `.foundry/project-type` (one line: `client` or `internal`), defaulting to **client** — fail-safe: loading extra rules is harmless, silently skipping binding rules is not. Tested by `bin/__tests__/constitution-tiering.test.sh`; the article list there MUST stay in sync with this map.
+
+> **Amending the map:** moving an article between tiers is a `constitution`-labeled amendment (close-on-diff rule applies) and MUST update the loader's article list in the same commit.
 
 ---
 
@@ -296,6 +299,8 @@ AI sessions drift. Models get deprecated. APIs change. Documentation goes stale.
 ---
 
 ## Article 16: Slack Is The Console
+
+> **📎 CLIENT tier** — binding for client-delivery projects; internal / tooling / methodology runs may skip. See the Loading Map.
 
 For EVERY LifeModo (and similar) project: **Slack is the primary interface.** The Console.
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -22,9 +22,9 @@ The Constitution loads in tiers so a run only carries the rules it needs (the #1
 - **CLIENT tier** — client-delivery doctrine. The paperwork, interface conventions, and billing of running a paid engagement. Loaded **only for client-delivery projects**; internal / tooling / methodology runs skip it. Articles 14 (the 18 Documents), 16 (Slack Is The Console), 19 (Admin Doc Quality Gate), 23 (Service Billing Pre-Flight), 33 (Agreement), 34 (Work Ledger / DU billing).
 
 > **How the tier is decided:** the tier axis is **engagement type**. Engagement-shaped doctrine (client paperwork, client-facing interface conventions) is CLIENT; articles that carry their own product-shape applicability gates (22's "When This Applies" table, 31's explicit "Internal tools" coverage) stay CORE. An article tagged `📎 CLIENT tier` is binding only when the project is a client engagement.
-
+>
 > **Enforcement (#73):** `bin/lib/constitution-loader.sh` strips CLIENT-tier articles from the prompt for internal projects. Project type resolves from `FOUNDRY_PROJECT_TYPE` env, then `.foundry/project-type` (one line: `client` or `internal`), defaulting to **client** — fail-safe: loading extra rules is harmless, silently skipping binding rules is not. Tested by `bin/__tests__/constitution-tiering.test.sh`; the article list there MUST stay in sync with this map.
-
+>
 > **Amending the map:** moving an article between tiers is a `constitution`-labeled amendment (close-on-diff rule applies) and MUST update the loader's article list in the same commit.
 
 ---

--- a/bin/__tests__/constitution-tiering.test.sh
+++ b/bin/__tests__/constitution-tiering.test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# constitution-tiering.test.sh — unit tests for bin/lib/constitution-loader.sh (#73).
+# Runs against the REAL CONSTITUTION.md so boundary regressions (an awk strip
+# eating an adjacent CORE article) are caught against the live document, not a toy.
+# Fails-before/passes-after: with the pre-#73 loader (plain cat), the internal-mode
+# assertions below fail.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONSTITUTION="$REPO_ROOT/CONSTITUTION.md"
+# shellcheck source=../lib/constitution-loader.sh
+. "$REPO_ROOT/bin/lib/constitution-loader.sh"
+
+PASS=0
+FAIL=0
+
+check() {
+  local desc="$1" ; local ok="$2"
+  if [ "$ok" = "0" ]; then
+    echo "  ok  - $desc" ; PASS=$((PASS+1))
+  else
+    echo "  FAIL - $desc" ; FAIL=$((FAIL+1))
+  fi
+}
+
+contains()     { printf '%s' "$1" | grep -qF -- "$2"; }
+not_contains() { ! printf '%s' "$1" | grep -qF -- "$2"; }
+
+echo "# internal project: CLIENT-tier articles stripped, CORE intact"
+INTERNAL="$(load_constitution "$CONSTITUTION" internal)"
+not_contains "$INTERNAL" "## Article 14:"; check "Article 14 (18 Documents) stripped" $?
+not_contains "$INTERNAL" "## Article 16:"; check "Article 16 (Slack Console) stripped" $?
+not_contains "$INTERNAL" "## Article 19:"; check "Article 19 (Admin Quality Gate) stripped" $?
+not_contains "$INTERNAL" "## Article 23:"; check "Article 23 (Service Billing) stripped" $?
+not_contains "$INTERNAL" "## Article 33:"; check "Article 33 (Agreement) stripped" $?
+not_contains "$INTERNAL" "## Article 34:"; check "Article 34 (Work Ledger) stripped" $?
+not_contains "$INTERNAL" "Development Units (DUs)"; check "DU-ledger body text gone" $?
+
+echo "# tail-leak canaries: one LATE-body string per stripped article (fence-blind"
+echo "# unskip leaked Article 34's tail past an embedded '## ' line — never again)"
+not_contains "$INTERNAL" "all 18 substantially complete"; check "Article 14 tail gone" $?
+not_contains "$INTERNAL" "Fob and Circles are phone-native"; check "Article 16 tail gone" $?
+not_contains "$INTERNAL" "Never leave a corrupted issue"; check "Article 19 tail gone" $?
+not_contains "$INTERNAL" 'quota exceeded'; check "Article 23 body gone" $?
+not_contains "$INTERNAL" "combined SOW + MOU"; check "Article 33 body gone" $?
+not_contains "$INTERNAL" "Six-Hat DU Rates"; check "Article 34 tail (DU rate card) gone" $?
+not_contains "$INTERNAL" "## Work Ledger"; check "Article 34 embedded fake-H2 gone" $?
+
+echo "# structural integrity: stripping must not unbalance markdown fences"
+INT_FENCES="$(printf '%s\n' "$INTERNAL" | grep -c '^```')"
+[ $((INT_FENCES % 2)) -eq 0 ]; check "internal output has even fence count ($INT_FENCES)" $?
+
+echo "# boundary correctness: articles adjacent to stripped ones survive"
+contains "$INTERNAL" "## Article 13:"; check "Article 13 (before 14) intact" $?
+contains "$INTERNAL" "## Article 15:"; check "Article 15 (after 14) intact" $?
+contains "$INTERNAL" "## Article 17:"; check "Article 17 (after 16) intact" $?
+contains "$INTERNAL" "## Article 20:"; check "Article 20 (after 19) intact" $?
+contains "$INTERNAL" "## Article 24:"; check "Article 24 (after 23) intact" $?
+contains "$INTERNAL" "## Article 32:"; check "Article 32 (before 33) intact" $?
+contains "$INTERNAL" "## Article 35:"; check "Article 35 (after 34) intact" $?
+contains "$INTERNAL" "## Article 36:"; check "Article 36 intact" $?
+contains "$INTERNAL" "## Article 1:";  check "Article 1 intact" $?
+contains "$INTERNAL" "## Article 8b:"; check "Article 8b (letter suffix) intact" $?
+contains "$INTERNAL" "## Loading Map"; check "Loading Map section intact" $?
+contains "$INTERNAL" "## Amendments";  check "Amendments section intact" $?
+contains "$INTERNAL" "## Article 22:"; check "Article 22 (borderline, ruled CORE) intact" $?
+contains "$INTERNAL" "## Article 31:"; check "Article 31 (borderline, ruled CORE) intact" $?
+
+echo "# client project: nothing stripped"
+CLIENT="$(load_constitution "$CONSTITUTION" client)"
+contains "$CLIENT" "## Article 14:"; check "Article 14 present for client" $?
+contains "$CLIENT" "## Article 34:"; check "Article 34 present for client" $?
+[ "$CLIENT" = "$(cat "$CONSTITUTION")" ]; check "client output matches file content (modulo trailing newline)" $?
+
+echo "# project-type resolution"
+TMPDIR_T="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_T"' EXIT
+
+T="$(FOUNDRY_PROJECT_TYPE= foundry_project_type "$TMPDIR_T")"
+[ "$T" = "client" ]; check "no config anywhere → client (fail-safe default)" $?
+
+printf 'internal\n' > "$TMPDIR_T/project-type"
+T="$(FOUNDRY_PROJECT_TYPE= foundry_project_type "$TMPDIR_T")"
+[ "$T" = "internal" ]; check "project-type file 'internal' honored" $?
+
+printf ' Internal \n' > "$TMPDIR_T/project-type"
+T="$(FOUNDRY_PROJECT_TYPE= foundry_project_type "$TMPDIR_T")"
+[ "$T" = "internal" ]; check "whitespace + case normalized" $?
+
+T="$(FOUNDRY_PROJECT_TYPE=client foundry_project_type "$TMPDIR_T")"
+[ "$T" = "client" ]; check "env var overrides file" $?
+
+printf 'banana\n' > "$TMPDIR_T/project-type"
+T="$(FOUNDRY_PROJECT_TYPE= foundry_project_type "$TMPDIR_T" 2>/dev/null)"
+[ "$T" = "client" ]; check "unknown value → client (fail-safe)" $?
+
+echo "# context savings are real (floor set near true savings so partial-strip"
+echo "# regressions — e.g. a tail leak — drag it below the bar)"
+INT_BYTES="$(printf '%s' "$INTERNAL" | wc -c)"
+CLI_BYTES="$(printf '%s' "$CLIENT" | wc -c)"
+SAVED=$((CLI_BYTES - INT_BYTES))
+[ "$SAVED" -gt 17000 ]; check "internal strip saves >17KB (actual: ${SAVED} bytes)" $?
+
+echo ""
+echo "constitution-tiering: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/bin/__tests__/constitution-tiering.test.sh
+++ b/bin/__tests__/constitution-tiering.test.sh
@@ -76,22 +76,22 @@ echo "# project-type resolution"
 TMPDIR_T="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR_T"' EXIT
 
-T="$(FOUNDRY_PROJECT_TYPE= foundry_project_type "$TMPDIR_T")"
+T="$(FOUNDRY_PROJECT_TYPE="" foundry_project_type "$TMPDIR_T")"
 [ "$T" = "client" ]; check "no config anywhere → client (fail-safe default)" $?
 
 printf 'internal\n' > "$TMPDIR_T/project-type"
-T="$(FOUNDRY_PROJECT_TYPE= foundry_project_type "$TMPDIR_T")"
+T="$(FOUNDRY_PROJECT_TYPE="" foundry_project_type "$TMPDIR_T")"
 [ "$T" = "internal" ]; check "project-type file 'internal' honored" $?
 
 printf ' Internal \n' > "$TMPDIR_T/project-type"
-T="$(FOUNDRY_PROJECT_TYPE= foundry_project_type "$TMPDIR_T")"
+T="$(FOUNDRY_PROJECT_TYPE="" foundry_project_type "$TMPDIR_T")"
 [ "$T" = "internal" ]; check "whitespace + case normalized" $?
 
 T="$(FOUNDRY_PROJECT_TYPE=client foundry_project_type "$TMPDIR_T")"
 [ "$T" = "client" ]; check "env var overrides file" $?
 
 printf 'banana\n' > "$TMPDIR_T/project-type"
-T="$(FOUNDRY_PROJECT_TYPE= foundry_project_type "$TMPDIR_T" 2>/dev/null)"
+T="$(FOUNDRY_PROJECT_TYPE="" foundry_project_type "$TMPDIR_T" 2>/dev/null)"
 [ "$T" = "client" ]; check "unknown value → client (fail-safe)" $?
 
 echo "# context savings are real (floor set near true savings so partial-strip"

--- a/bin/foundry.sh
+++ b/bin/foundry.sh
@@ -64,6 +64,10 @@ CONSTITUTION_CORE="$SCRIPT_DIR/CONSTITUTION-CORE.md"
 CONSTITUTION_FULL="$SCRIPT_DIR/CONSTITUTION.md"
 CONSTITUTION_FILE="$CONSTITUTION_CORE"  # default to core; overridden per stage below
 
+# Progressive-disclosure tiering (#73): CLIENT-tier articles are stripped for
+# internal projects per the Loading Map in CONSTITUTION.md.
+. "$SCRIPT_DIR/bin/lib/constitution-loader.sh"
+
 # Permission tiers — CC3 F1 fix (Via Negativa: remove permissions you don't need)
 # Read-only stages run WITHOUT --dangerously-skip-permissions (safe default).
 # Write stages (code, validate, e2e, pr, fsd) get full permissions.
@@ -499,9 +503,15 @@ run_stage() {
 
   # Build the full prompt with context layers
   # Layer 1: Constitution (immutable rules — always first)
+  # Tiering (#73): internal projects skip CLIENT-tier articles (Loading Map).
   local full_prompt=""
   if [ -f "$CONSTITUTION_FILE" ]; then
-    full_prompt="$(cat "$CONSTITUTION_FILE")
+    local project_type
+    project_type="$(foundry_project_type "$PROJECT_DIR/$DARK_FOUNDRY_DIR")"
+    if [ "$project_type" = "internal" ] && [ "$CONSTITUTION_FILE" = "$CONSTITUTION_FULL" ]; then
+      echo "[constitution] internal project — CLIENT-tier articles (14,16,19,23,33,34) skipped"
+    fi
+    full_prompt="$(load_constitution "$CONSTITUTION_FILE" "$project_type")
 
 ---
 

--- a/bin/lib/constitution-loader.sh
+++ b/bin/lib/constitution-loader.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# constitution-loader.sh — progressive-disclosure loading of the Constitution (#73).
+# Enforces the Loading Map in CONSTITUTION.md: CLIENT-tier articles are stripped
+# from the prompt for internal (non-client-engagement) projects.
+#
+# Function library only — no side effects on source. Bash 3.2 compatible (macOS).
+# Sourced by bin/foundry.sh; unit-tested by bin/__tests__/constitution-tiering.test.sh.
+
+# CLIENT-tier article numbers — MUST match the Loading Map in CONSTITUTION.md.
+# 14 (18 Documents), 16 (Slack Console), 19 (Admin Doc Quality Gate),
+# 23 (Service Billing Pre-Flight), 33 (Agreement), 34 (Work Ledger).
+FOUNDRY_CLIENT_TIER_ARTICLES="14|16|19|23|33|34"
+
+# foundry_project_type <.foundry-dir>
+# Resolution order: FOUNDRY_PROJECT_TYPE env → <.foundry-dir>/project-type file → "client".
+# DEFAULT IS client (fail-safe): loading extra rules is harmless; silently skipping
+# binding rules is not. Internal projects opt IN to the context savings.
+# Unknown values fall back to client with a warning on stderr.
+foundry_project_type() {
+  local foundry_dir="${1:-}"
+  local raw=""
+  if [ -n "${FOUNDRY_PROJECT_TYPE:-}" ]; then
+    raw="$FOUNDRY_PROJECT_TYPE"
+  elif [ -n "$foundry_dir" ] && [ -f "$foundry_dir/project-type" ]; then
+    raw="$(head -1 "$foundry_dir/project-type")"
+  fi
+  # trim + lowercase (tr, not ${var,,} — bash 3.2)
+  raw="$(printf '%s' "$raw" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
+  case "$raw" in
+    client|internal) printf '%s' "$raw" ;;
+    "")              printf 'client' ;;
+    *)
+      echo "[WARN] Unknown project type '${raw}' — defaulting to client (all articles load)" >&2
+      printf 'client' ;;
+  esac
+}
+
+# load_constitution <constitution-file> <project-type>
+# Prints the constitution to stdout. For internal projects, strips CLIENT-tier
+# articles (header through the line before the next '## ' heading). CORE-tier
+# articles and non-article sections (Loading Map, Amendments) are never touched.
+#
+# FENCE-AWARE (adversarial review, #73): article bodies contain fenced code
+# templates with lines that LOOK like H2 headings (e.g. '## Work Ledger' inside
+# Article 34's template). Heading rules only apply outside ``` fences — a
+# fence-blind version leaked Article 34's entire DU rate card into internal
+# output. Fence state is tracked on every line, including skipped ones.
+load_constitution() {
+  local file="$1"
+  local project_type="${2:-client}"
+  if [ "$project_type" != "internal" ]; then
+    cat "$file"
+    return
+  fi
+  awk -v arts="$FOUNDRY_CLIENT_TIER_ARTICLES" '
+    BEGIN { pat = "^## Article (" arts "):" ; skip = 0 ; fence = 0 }
+    /^```/             { fence = !fence }
+    !fence && $0 ~ pat { skip = 1; next }
+    !fence && /^## /   { skip = 0 }
+    !skip              { print }
+  ' "$file"
+}


### PR DESCRIPTION
Completes the progressive-disclosure work: the Loading Map's tier tags are now **enforced by the pipeline**, not advisory. CTO-takeover execution per Roderic's mandate on #71. Closes #73.

## Borderline rulings (the #71 open thread, decided with evidence)

- **Article 16 (Slack Is The Console) → CLIENT.** Its own text is engagement-shaped: "For EVERY LifeModo (and similar) project… invisible to the client."
- **Article 22 (Platform Self-Awareness) → stays CORE.** Carries its own "When This Applies" table keyed on product shape, explicitly not engagement type.
- **Article 31 (Linear UI) → stays CORE.** Its applicability list explicitly includes "Internal tools" and "Admin dashboards" — client-gating it would contradict its own text.

Principle recorded in the Loading Map: the tier axis is **engagement type**; articles with their own product-shape gates stay CORE.

## What's in the diff

- **`bin/lib/constitution-loader.sh`** — strips CLIENT-tier articles (14, 16, 19, 23, 33, 34) for internal projects. Project type: `FOUNDRY_PROJECT_TYPE` env → `.foundry/project-type` → **default `client`** (fail-safe: loading extra rules is harmless; silently skipping binding rules is not). Bash 3.2 compatible (macOS).
- **`bin/foundry.sh`** — sources the lib at the constitution constants; the prompt build calls `load_constitution` and logs when stripping.
- **`bin/__tests__/constitution-tiering.test.sh`** — 38 checks: strip + adjacency for every seam, per-article **tail-leak canaries**, **markdown fence balance**, project-type resolution matrix, savings floor >17KB (actual: 18,256 bytes per internal full-load stage).
- **`.github/workflows/foundry-ci.yml`** — first CI for this repo (ubuntu-latest; independent of the self-hosted Mac fleet).
- **`CONSTITUTION.md` → v3.2** — rulings + enforcement note in the Loading Map; changelog; 8b named explicitly. `CONSTITUTION-CORE.md` version synced.

## The bug adversarial review caught before merge

A 4-lens adversarial verification (awk boundaries / shell robustness / test quality / doc consistency) ran against the first version of this change. Two lenses independently confirmed a REAL bug the then-green test suite missed: the awk unskip rule `/^## /` fired on **`## Work Ledger` inside Article 34's fenced code template** (CONSTITUTION.md:1423), leaking the entire Six-Hat DU billing rate card into "internal" output and unbalancing markdown fences for the rest of the document. The loader is now **fence-aware** (heading rules only apply outside ``` fences), and the suite gained the canaries + fence-balance assertion that catch that class: hardened suite vs fence-blind loader = **6 failures**; vs fixed loader = **38/38**.

## Verification

- Fails-before/passes-after demonstrated for both the original loader (11 failures on plain-cat stub) and the fence bug (6 failures on fence-blind stub).
- Real-output spot-check: Article 33/34 → 35 seam clean, fence count even (34), zero leaked billing content; the only remaining "DU" mentions are the Loading Map's own index entry and CORE Article 11's estimate unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLo2Hyd1z8nrQSp7e476uA8

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLo2Hyd1z8nrQSp7e47uA8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Constitution content now adapts to project type, omitting client-specific guidance for internal projects while preserving it for client projects.
  * Added project-type detection through configuration files and environment settings, with safe defaults.
  * Added safeguards to prevent accidental content leakage when filtering constitution sections.

* **Documentation**
  * Updated constitution versions, ratification details, tier assignments, and loading guidance.
  * Article 16 is now designated as CLIENT-tier guidance.

* **Tests**
  * Added automated coverage for tier filtering, configuration resolution, and content integrity.

* **Chores**
  * Added continuous integration checks for syntax validation and constitution tiering tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->