### PR TITLE
Harden #73 loader source — missing lib must not brick the orchestrator

### DIFF
--- a/bin/__tests__/constitution-tiering.test.sh
+++ b/bin/__tests__/constitution-tiering.test.sh
@@ -101,6 +101,25 @@ CLI_BYTES="$(printf '%s' "$CLIENT" | wc -c)"
 SAVED=$((CLI_BYTES - INT_BYTES))
 [ "$SAVED" -gt 17000 ]; check "internal strip saves >17KB (actual: ${SAVED} bytes)" $?
 
+echo "# defensive source: a MISSING loader lib must NOT brick foundry.sh"
+echo "# (it runs under 'set -euo pipefail'; a bare failed source aborts at startup)"
+# Reproduce the exact guard block from bin/foundry.sh against a missing path.
+MISS_OUT="$(bash -c '
+  set -euo pipefail
+  SCRIPT_DIR="/tmp/does-not-exist-$$"
+  if [ -f "$SCRIPT_DIR/bin/lib/constitution-loader.sh" ] && . "$SCRIPT_DIR/bin/lib/constitution-loader.sh"; then :; else
+    foundry_project_type() { printf "client"; }
+    load_constitution() { cat "$1"; }
+  fi
+  printf "continued:%s" "$(foundry_project_type /x)"
+' 2>/dev/null)"; MISS_RC=$?
+[ "$MISS_RC" -eq 0 ]; check "missing lib does not abort under set -e (rc=$MISS_RC)" $?
+[ "$MISS_OUT" = "continued:client" ]; check "missing lib falls back to client (loads full constitution)" $?
+# And prove foundry.sh actually contains the defensive guard, not a bare source.
+FOUNDRY_SH="$REPO_ROOT/bin/foundry.sh"
+grep -q 'if \[ -f "\$SCRIPT_DIR/bin/lib/constitution-loader.sh" \]' "$FOUNDRY_SH"; check "foundry.sh guards the source (not a bare '. lib')" $?
+! grep -qE '^\. "\$SCRIPT_DIR/bin/lib/constitution-loader.sh"' "$FOUNDRY_SH"; check "no unguarded top-level source remains" $?
+
 echo ""
 echo "constitution-tiering: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/bin/foundry.sh
+++ b/bin/foundry.sh
@@ -66,7 +66,19 @@ CONSTITUTION_FILE="$CONSTITUTION_CORE"  # default to core; overridden per stage 
 
 # Progressive-disclosure tiering (#73): CLIENT-tier articles are stripped for
 # internal projects per the Loading Map in CONSTITUTION.md.
-. "$SCRIPT_DIR/bin/lib/constitution-loader.sh"
+# DEFENSIVE SOURCE: a missing lib must NOT brick the orchestrator (it runs under
+# 'set -euo pipefail', where a bare failed source aborts at startup — strictly
+# worse than the pre-#73 warn-and-continue behavior). If the lib is absent or
+# fails to load, fall back to full-constitution loading (old behavior) with a
+# warning; the pipeline still runs, just without tier stripping.
+if [ -f "$SCRIPT_DIR/bin/lib/constitution-loader.sh" ] \
+   && . "$SCRIPT_DIR/bin/lib/constitution-loader.sh"; then
+  :
+else
+  echo "[WARN] constitution-loader.sh missing/failed — CLIENT-tier stripping disabled; loading full constitution (safe: more rules, never fewer)." >&2
+  foundry_project_type() { printf 'client'; }
+  load_constitution() { cat "$1"; }
+fi
 
 # Permission tiers — CC3 F1 fix (Via Negativa: remove permissions you don't need)
 # Read-only stages run WITHOUT --dangerously-skip-permissions (safe default).


### PR DESCRIPTION
Follow-up to #74. A QA red-team pass (hunting **second-order effects on existing code**) found a real regression the merged #73 work introduced.

## The bug

`bin/foundry.sh` runs under `set -euo pipefail`. The #73 change added a **bare top-level source**:

```sh
. "$SCRIPT_DIR/bin/lib/constitution-loader.sh"
```

Under `set -e`, if that lib is missing, the source returns 1 and **aborts the entire orchestrator at startup** — before any pipeline logic runs. Proven:

```
$ bash -c 'set -euo pipefail; . /nonexistent/constitution-loader.sh; echo reached'
bash: .../constitution-loader.sh: No such file or directory
exit=1    # "reached" never prints
```

The **pre-#73 behavior degraded gracefully**: constitution loading was wrapped in `if [ -f ]` with an `else` that warned "Pipeline will run WITHOUT immutable rules" and continued. My tiering change silently turned a brand-new file into a hard startup dependency of the crown-jewel pipeline — a partial checkout, an older clone, or a renamed lib now bricks `foundry.sh` with a cryptic bash error. Strictly worse than before.

## The fix

Defensive source — if the lib is absent or fails to load, warn and fall back to full-constitution loading (`client` default: more rules, never fewer), so the pipeline still runs:

```sh
if [ -f "$SCRIPT_DIR/bin/lib/constitution-loader.sh" ] \
   && . "$SCRIPT_DIR/bin/lib/constitution-loader.sh"; then :
else
  echo "[WARN] constitution-loader.sh missing/failed — CLIENT-tier stripping disabled; loading full constitution" >&2
  foundry_project_type() { printf 'client'; }
  load_constitution() { cat "$1"; }
fi
```

(A failed command inside an `if` condition is exempt from `set -e`, so this can't itself abort.)

## Verification

- **Missing lib** → warns, continues, `foundry_project_type` returns `client`, full constitution loads (exit 0). 
- **Present lib** → real functions load, stripping works (72,768 vs 91,024 bytes).
- **4 new regression checks**: behavioral no-abort under `set -e`, `client` fallback, plus two structural guards asserting `foundry.sh` contains the guarded form and no unguarded bare source. Suite **42/42**, proven fails-before (2 structural failures on the bare-source version).

## Why no browser test

This is a bash loader in a CLI pipeline — no web surface, no DOM, no deployed URL. The equivalent-rigor check is executing the actual failure path under `set -euo pipefail`, shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLo2Hyd1z8nrQSp7e47uA8

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLo2Hyd1z8nrQSp7e47uA8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup reliability when the constitution loader is unavailable.
  - Added a safe fallback that allows processing to continue and produces expected output.
  - Preserved standard behavior when the constitution loader is present.
- **Tests**
  - Added coverage for missing-loader scenarios under strict shell execution settings.
  - Verified guarded loading and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->