### PR TITLE
Harden CLIENT-tier strip against ~~~ fences + nested fence syntaxes (#73)

### DIFF
--- a/bin/__tests__/constitution-tiering.test.sh
+++ b/bin/__tests__/constitution-tiering.test.sh
@@ -120,6 +120,41 @@ FOUNDRY_SH="$REPO_ROOT/bin/foundry.sh"
 grep -q 'if \[ -f "\$SCRIPT_DIR/bin/lib/constitution-loader.sh" \]' "$FOUNDRY_SH"; check "foundry.sh guards the source (not a bare '. lib')" $?
 ! grep -qE '^\. "\$SCRIPT_DIR/bin/lib/constitution-loader.sh"' "$FOUNDRY_SH"; check "no unguarded top-level source remains" $?
 
+echo "# synthetic fence adversarial cases (#75): tilde fences + nested syntaxes"
+echo "# must not let a fake '## ' heading inside a code block reopen the strip"
+SAVED_ARTS="$FOUNDRY_CLIENT_TIER_ARTICLES"
+FOUNDRY_CLIENT_TIER_ARTICLES="14"
+FIX="$TMPDIR_T/fixture.md"
+
+# Case A — a ~~~ fenced block inside a stripped article, wrapping a fake H2.
+# Backtick-only fence tracking (pre-#75) would miss the ~~~, see the fake H2 as a
+# real heading, unskip, and leak the article tail + the CORE article's identity.
+printf '%s\n' \
+  '## Article 14: Client' '> banner' 'body A' \
+  '~~~' '## Fake tilde heading' 'x' '~~~' \
+  'tail-of-14-CANARY' \
+  '## Article 15: Core' 'kept-body-A' > "$FIX"
+OUT_A="$(load_constitution "$FIX" internal)"
+not_contains "$OUT_A" "Fake tilde heading"; check "A: fake H2 inside ~~~ fence not leaked" $?
+not_contains "$OUT_A" "tail-of-14-CANARY";  check "A: stripped article tail not leaked" $?
+contains     "$OUT_A" "## Article 15: Core"; check "A: following CORE article survives" $?
+contains     "$OUT_A" "kept-body-A";         check "A: CORE body survives" $?
+
+# Case B — a ``` block whose CONTENT includes a ~~~ line and a fake H2. A naive
+# both-toggle tracker (flip on ``` OR ~~~) would treat the inner ~~~ as a close,
+# fall outside the fence, and leak the fake H2. Char-tracking keeps the ``` open.
+printf '%s\n' \
+  '## Article 14: Client' '> banner' \
+  '```' '~~~ inner tilde is content' '## Fake heading in backtick block' '```' \
+  'tail-of-14-CANARY-B' \
+  '## Article 15: Core' 'kept-body-B' > "$FIX"
+OUT_B="$(load_constitution "$FIX" internal)"
+not_contains "$OUT_B" "Fake heading in backtick block"; check "B: fake H2 in \`\`\` (w/ inner ~~~) not leaked" $?
+not_contains "$OUT_B" "tail-of-14-CANARY-B"; check "B: article tail not leaked past nested syntax" $?
+contains     "$OUT_B" "kept-body-B";         check "B: CORE body survives" $?
+
+FOUNDRY_CLIENT_TIER_ARTICLES="$SAVED_ARTS"
+
 echo ""
 echo "constitution-tiering: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/bin/lib/constitution-loader.sh
+++ b/bin/lib/constitution-loader.sh
@@ -40,11 +40,16 @@ foundry_project_type() {
 # articles (header through the line before the next '## ' heading). CORE-tier
 # articles and non-article sections (Loading Map, Amendments) are never touched.
 #
-# FENCE-AWARE (adversarial review, #73): article bodies contain fenced code
+# FENCE-AWARE (adversarial review, #73 / #75): article bodies contain fenced code
 # templates with lines that LOOK like H2 headings (e.g. '## Work Ledger' inside
-# Article 34's template). Heading rules only apply outside ``` fences — a
+# Article 34's template). Heading rules only apply OUTSIDE code fences — a
 # fence-blind version leaked Article 34's entire DU rate card into internal
-# output. Fence state is tracked on every line, including skipped ones.
+# output. Both fence syntaxes are handled: ``` and ~~~. Per CommonMark they are
+# independent — a fence opened with one char is closed only by the SAME char, so
+# a ~~~ line inside a ``` block (or vice-versa) is content, not a delimiter. We
+# track the OPENING fence char, not a naive toggle, so nested-syntax cases can't
+# spuriously flip fence state and reopen the leak. State tracks every line,
+# including skipped ones.
 load_constitution() {
   local file="$1"
   local project_type="${2:-client}"
@@ -53,8 +58,12 @@ load_constitution() {
     return
   fi
   awk -v arts="$FOUNDRY_CLIENT_TIER_ARTICLES" '
-    BEGIN { pat = "^## Article (" arts "):" ; skip = 0 ; fence = 0 }
-    /^```/             { fence = !fence }
+    BEGIN { pat = "^## Article (" arts "):" ; skip = 0 ; fence = 0 ; fchar = "" }
+    /^(```|~~~)/ {
+      ch = substr($0, 1, 1)
+      if (fence == 0)      { fence = 1; fchar = ch }
+      else if (ch == fchar){ fence = 0; fchar = "" }
+    }
     !fence && $0 ~ pat { skip = 1; next }
     !fence && /^## /   { skip = 0 }
     !skip              { print }


### PR DESCRIPTION
Closes the last dormant latent in the tiering loader, flagged in #75's Volcano.

## The gap

`#73`'s fence-awareness tracked only ` ``` ` fences. A `~~~` fenced block inside a CLIENT-tier article — wrapping a line that looks like an H2 heading — would slip past the tracker, be read as a real heading, unskip the strip, and leak the article tail into internal output. Exactly the DU-rate-card leak class, via the other CommonMark fence syntax.

## The fix

Track **both** ` ``` ` and `~~~`, with correct CommonMark semantics: a fence opened by one char is closed **only by the same char**. So a `~~~` line inside a ` ``` ` block (or vice-versa) is content, not a delimiter. This is char-tracking, **not** a naive both-toggle — a both-toggle would itself break on nested syntax.

## Proof (fails-before against *two* wrong implementations)

| Loader version | Result |
|---|---|
| Backtick-only (pre-this-PR) | **FAILS Case A** — `~~~` block with fake H2 leaks |
| Naive both-toggle | **FAILS Case B** — inner `~~~` inside ` ``` ` prematurely closes, fake H2 leaks |
| Char-tracking (this PR) | **49/49 pass** |

Two synthetic adversarial fixtures added to the suite (Case A: `~~~` block wrapping a fake H2; Case B: ` ``` ` block whose content includes a `~~~` line and a fake H2). There is no live `~~~` in CONSTITUTION.md today — this hardens the class before anyone adds one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLo2Hyd1z8nrQSp7e47uA8

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLo2Hyd1z8nrQSp7e47uA8)_